### PR TITLE
Outbound FIFO (THR) is not used.

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -296,6 +296,8 @@ static unsigned char PIC_READ_IRR(unsigned int port){PIC_WRITE_OCW3(port, PIC_RR
 #define UART_BPS_DIVISOR_57600         2
 #define UART_BPS_DIVISOR_115200        1
 
+/* FIFO size */
+#define UART_FIFO_SIZE_IN_BYTES       16
 
 /* ======================================================================== */
 /* ==================== PROTOTYPES, TYPEDEFS & GLOBALS ==================== */
@@ -456,7 +458,7 @@ static void Interrupt com_general_isr(void)
                         break;
                     /* UART is empty */
                     case UART_IIR_TX_HOLD_EMPTY:
-                        while(com->tx_flow_on && UART_READ_LINE_STATUS(com) & UART_LSR_TX_HOLD_EMPTY && !SER_TX_BUFFER_EMPTY(com))
+                        for (int cnt=0; cnt<UART_FIFO_SIZE_IN_BYTES && com->tx_flow_on && !SER_TX_BUFFER_EMPTY(com); cnt++)
                             UART_WRITE_DATA(com, SER_TX_BUFFER_READ(com));
                         if(SER_TX_BUFFER_EMPTY(com) || !com->tx_flow_on)
                             UART_WRITE_INTERRUPT_ENABLE(com, UART_READ_INTERRUPT_ENABLE(com) & ~UART_IER_TX_HOLD_EMPTY);


### PR DESCRIPTION
I've been adding a serial logger to an MS-DOS project, using this source as a guide.  It has been very helpful.

I noticed something odd about the way the ISR handles the THR_EMPTY condition.

If I understand correctly, THR_EMPTY is set when the TX buffer is empty, but there may be a byte left in the internal shift register.  (At 115200 baud this gives about 5000-10000 cycles (~7500 on a Pentium 100Mhz) to replenish the TX fifo data, I believe)

Since the FIFO holds 16 bytes, I would expect the ISR to push up to that many into the THR when raised.  However, the original code seems to push until THR_EMPTY is clear -- which I would expect to happen after the very first byte.  In other words, the THR isn't being used.

To verify it, I had a program output a few hundred bytes, incrementing an IRQ counter in the THR_EMPTY isr.  The modified version's IRQ-count is 1/16 of the original.

It works fine in dosbox.  It will be a week or so before I can test it on real hardware.